### PR TITLE
initial ko_dry_resolve implementation

### DIFF
--- a/examples/data/ko_dry_resolve/data.tf
+++ b/examples/data/ko_dry_resolve/data.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    ko = {
+      source  = "unicorn/fart/ko"
+      version = "0.1.0"
+    }
+  }
+}
+
+provider "ko" {
+  docker_repo = "ttl.sh/booker"
+}
+
+data "ko_dry_resolve" "example" {
+  filenames = ["../../../testdata"]
+  recursive = true
+}
+
+output "id" {
+  value = data.ko_dry_resolve.example.id
+}
+
+output "manifests" {
+  value = data.ko_dry_resolve.example.manifests
+}

--- a/examples/resources/ko_resolve/resource.tf
+++ b/examples/resources/ko_resolve/resource.tf
@@ -1,5 +1,19 @@
+terraform {
+  required_providers {
+    ko = {
+      source  = "unicorn/fart/ko"
+      version = "0.1.0"
+    }
+  }
+}
+
 provider "ko" {
   docker_repo = "ttl.sh/booker"
+}
+
+data "ko_dry_resolve" "example" {
+  filenames = ["../../../testdata/k8s.yaml"]
+  recursive = false
 }
 
 resource "ko_resolve" "example" {
@@ -14,3 +28,20 @@ output "id" {
 output "manifests" {
   value = ko_resolve.example.manifests
 }
+
+provider "kubernetes" {
+  config_path    = "~/.kube/config"
+  config_context = "k3d-k3s-default"
+}
+
+resource "kubernetes_manifest" "name" {
+  # count    = length(data.ko_dry_resolve.example)
+  # manifest = yamldecode(ko_resolve.example.manifests[count.index])
+
+  count    = length(data.ko_dry_resolve.example.manifests)
+  manifest = yamldecode(ko_resolve.example.manifests[count.index])
+}
+
+# output "dry" {
+#   value = data.ko_dry_resolve.example.manifests
+# }

--- a/internal/provider/data_ko_resolve.go
+++ b/internal/provider/data_ko_resolve.go
@@ -1,0 +1,150 @@
+package provider
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/ko/pkg/build"
+	"github.com/google/ko/pkg/commands"
+	"github.com/google/ko/pkg/commands/options"
+	"github.com/google/ko/pkg/publish"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataDryResolveConfig() *schema.Resource {
+	return &schema.Resource{
+		Description: "",
+
+		ReadContext: dataDryResolveConfigRead,
+
+		Schema: map[string]*schema.Schema{
+			FilenamesKey: {
+				Description: "Filenames, directorys, or URLs to files to use to create the resource",
+				Required:    true,
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				ForceNew:    true,
+			},
+			RecursiveKey: {
+				Description: "Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.",
+				Optional:    true,
+				Type:        schema.TypeBool,
+				ForceNew:    true,
+			},
+			SelectorKey: {
+				Description: "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)",
+				Optional:    true,
+				Type:        schema.TypeString,
+				ForceNew:    true,
+			},
+
+			// Computed fields
+			ManifestsKey: {
+				Description: "A list of resolved manifests in a 'yamldecode'able format. Note that whitespaces and nil docs will be stripped from these results.",
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
+			},
+		},
+	}
+}
+
+// dryResolver is an implementation of Resolver that doesn't actually build anything
+type dryResolver struct {
+	fo *options.FilenameOptions
+	so *options.SelectorOptions
+}
+
+func NewDryResolver(d *schema.ResourceData, meta interface{}) (*dryResolver, error) {
+	r := &dryResolver{
+		fo: &options.FilenameOptions{},
+		so: &options.SelectorOptions{},
+	}
+
+	if p, ok := d.Get(FilenamesKey).([]interface{}); ok {
+		r.fo.Filenames = StringSlice(p)
+	}
+
+	if p, ok := d.Get(RecursiveKey).(bool); ok {
+		r.fo.Recursive = p
+	}
+
+	if p, ok := d.Get(SelectorKey).(string); ok {
+		r.so.Selector = p
+	}
+
+	return r, nil
+}
+
+func (r *dryResolver) Resolve(ctx context.Context) (*Resolved, error) {
+	var resolveBuf bytes.Buffer
+	w := &nopWriteCloser{Writer: bufio.NewWriter(&resolveBuf)}
+
+	emptyBuilder, err := build.NewCaching(&emptyBuilder{})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := commands.ResolveFilesToWriter(ctx, emptyBuilder, &emptyPublisher{}, r.fo, r.so, w); err != nil {
+		return nil, err
+	}
+
+	if err := w.Flush(); err != nil {
+		return nil, err
+	}
+
+	return NewResolved(resolveBuf.Bytes())
+}
+
+func dataDryResolveConfigRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	r, err := NewDryResolver(d, meta)
+	if err != nil {
+		return diag.Errorf("building dry resolver: %v", err)
+	}
+
+	resolved, err := r.Resolve(ctx)
+	if err != nil {
+		return diag.Errorf("resolving: %v", err)
+	}
+
+	d.SetId(resolved.ID())
+	d.Set("manifests", resolved.Manifests)
+	return nil
+}
+
+var _ = build.Interface(&emptyBuilder{})
+
+type emptyBuilder struct{}
+
+// Build implements build.Interface
+func (*emptyBuilder) Build(ctx context.Context, ip string) (build.Result, error) {
+	return empty.Image, nil
+}
+
+// IsSupportedReference implements build.Interface
+func (*emptyBuilder) IsSupportedReference(string) error {
+	return nil
+}
+
+// QualifyImport implements build.Interface
+func (*emptyBuilder) QualifyImport(ip string) (string, error) {
+	return ip, nil
+}
+
+var _ = publish.Interface(&emptyPublisher{})
+
+type emptyPublisher struct{}
+
+// Close implements publish.Interface
+func (*emptyPublisher) Close() error {
+	return nil
+}
+
+// Publish implements publish.Interface
+func (*emptyPublisher) Publish(ctx context.Context, result build.Result, ip string) (name.Reference, error) {
+	return name.ParseReference(ip)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -42,6 +42,9 @@ func New(version string) func() *schema.Provider {
 				"ko_image":   resourceImage(),
 				"ko_resolve": resolveConfig(),
 			},
+			DataSourcesMap: map[string]*schema.Resource{
+				"ko_dry_resolve": dataDryResolveConfig(),
+			},
 		}
 
 		p.ConfigureContextFunc = configure(version, p)


### PR DESCRIPTION
__status__: DRAFT

this _does not work_, but wanted to show the implementation and discuss why:

```hcl
# YES
resource "kubernetes_manifest" "yes" {
  count    = length(data.ko_dry_resolve.example.manifests)
  manifest = yamldecode(data.ko_dry_resolve.example.manifests[count.index])
}

# NO
resource "kubernetes_manifest" "no" {
  count    = length(data.ko_dry_resolve.example.manifests)
  manifest = yamldecode(ko_resolve.example.manifests[count.index])
}
```

The corresponding error for `kubernetes_manifest.no` is:

```bash
# examples/resources/ko_resolve
➜ terraform apply
data.ko_dry_resolve.example: Reading...
data.ko_dry_resolve.example: Read complete after 0s [id=c8c616032f15bb0968f72dadc18bc34eaa8b1c2b300b6a491e3e3c7ac54c3fa5]
╷
│ Error: Failed to determine GroupVersionResource for manifest
│
│   with kubernetes_manifest.name[0],
│   on resource.tf line 37, in resource "kubernetes_manifest" "name":
│   37: resource "kubernetes_manifest" "name" {
│
│ unmarshaling unknown values is not supported
```

So even though the `n` manifests is known at runtime, we can't use that to feed into the computed `ko_resolve.*.manifests` resource since the "real" computed values don't exist yet.

Open to other ideas, but this current implementation is DOA :( 