### PR TITLE
Fix: `sbom=none` should disable SBOM production.

### DIFF
--- a/internal/provider/resource_ko_image.go
+++ b/internal/provider/resource_ko_image.go
@@ -265,7 +265,7 @@ func (o *buildOptions) makeBuilder(ctx context.Context) (*build.Caching, error) 
 	case "go.version-m":
 		bo = append(bo, build.WithGoVersionSBOM())
 	case "none":
-		// don't do anything.
+		bo = append(bo, build.WithDisabledSBOM())
 	default:
 		return nil, fmt.Errorf("unknown sbom type: %q", o.sbom)
 	}


### PR DESCRIPTION
:bug: the default is actually spdx.

/kind bug