### PR TITLE
Upgrade to go1.20 and other ci updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,30 +1,22 @@
-name: release
+name: Build
 on:
+  pull_request:
+    branches: ['main']
   push:
-    tags:
-      - 'v*'
+    branches: ['main']
+
 jobs:
-  goreleaser:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
-      - run: git fetch --prune --unshallow
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: '1.20'
           check-latest: true
-          cache: true
-
-      - id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549 # v5.2.0
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
-
       - uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4.2.0
         with:
           version: latest
-          args: release --clean
+          args: release --clean --snapshot --skip-sign
         env:
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,8 @@ jobs:
       - run: git fetch --prune --unshallow
       - uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.mod'
+          go-version: '1.20'
+          check-latest: true
           cache: true
 
       - id: import_gpg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,18 +9,16 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
-      with:
-        go-version: '1.18'
-    - run: go generate ./...
-    - name: git diff
-      run: |
-        git diff --compact-summary --exit-code || \
-          (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: '1.20'
           check-latest: true
+      - run: go generate ./...
+      - name: git diff
+        run: |
+          git diff --compact-summary --exit-code || \
+            (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
 
   test:
     name: Test
@@ -29,22 +27,20 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-        - '1.0.*'
-        - '1.1.*'
+          - '1.3.*'
+          - '1.4.*'
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
-      with:
-        go-version: '1.18'
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: '1.20'
           check-latest: true
 
-    - uses: hashicorp/setup-terraform@v2
-      with:
-        terraform_version: ${{ matrix.terraform }}
-        terraform_wrapper: false
+      - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
 
-    - run: go mod download
-    - run: go build -v .  
-    - run: TF_ACC=1 go test -v -cover ./internal/provider/
+      - run: go mod download
+      - run: go build -v .
+      - run: TF_ACC=1 go test -v -cover ./internal/provider/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
       run: |
         git diff --compact-summary --exit-code || \
           (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
+        with:
+          go-version: '1.20'
+          check-latest: true
 
   test:
     name: Test
@@ -33,6 +36,9 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: '1.18'
+        with:
+          go-version: '1.20'
+          check-latest: true
 
     - uses: hashicorp/setup-terraform@v2
       with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,24 @@
+name: verify
+
+on:
+  pull_request:
+    branches: ['main']
+  push:
+    branches: ['main']
+
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          go-version: '1.20'
+          check-latest: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
+        with:
+          version: v1.51
+          args: --timeout=5m

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ website/vendor
 *.winfile eol=crlf
 
 terraform-provider-ko
-.terraform.lock.hcl 
+.terraform.lock.hcl

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,26 @@
+run:
+  timeout: 5m
+
+issues:
+  exclude-rules:
+    - path: test # Excludes /test, *_test.go etc.
+      linters:
+        - gosec
+
+linters:
+  enable:
+    - asciicheck
+    - depguard
+    - errorlint
+    - gofmt
+    - gosec
+    - goimports
+    - importas
+    - prealloc
+    - revive
+    - misspell
+    - stylecheck
+    - tparallel
+    - unconvert
+    - unparam
+    - whitespace

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,37 +1,43 @@
 before:
+
   hooks:
-    - go mod tidy -compat=1.17
+    - go mod tidy
+    - /bin/bash -c 'if [ -n "$(git --no-pager diff --exit-code go.mod go.sum)" ]; then exit 1; fi'
+
 builds:
-- env:
-    - CGO_ENABLED=0
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-    - -trimpath
-  ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
-  goos:
-    - freebsd
-    - windows
-    - linux
-    - darwin
-  goarch:
-    - amd64
-    - '386'
-    - arm
-    - arm64
-  ignore:
-    - goos: darwin
-      goarch: '386'
-  binary: '{{ .ProjectName }}_v{{ .Version }}'
+  - env:
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: '386'
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
+
 archives:
-- format: zip
-  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  - format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+
 checksum:
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
+
 signs:
   - artifacts: checksum
     args:
@@ -42,11 +48,11 @@ signs:
       - "${signature}"
       - "--detach-sign"
       - "${artifact}"
+
 release:
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
-  # If you want to manually examine the release before its live, uncomment this line:
-  # draft: true
+
 changelog:
   skip: true

--- a/docs/resources/resolve.md
+++ b/docs/resources/resolve.md
@@ -36,7 +36,7 @@ output "manifests" {
 
 ### Required
 
-- `filenames` (List of String) Filenames, directorys, or URLs to files to use to create the resource
+- `filenames` (List of String) Filenames, directories, or URLs to files to use to create the resource
 
 ### Optional
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ko-build/terraform-provider-ko
 
-go 1.18
+go 1.20
 
 require (
 	github.com/aws/aws-lambda-go v1.38.0

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -11,8 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var changed = false
-
 func init() {
 	// Set descriptions to support markdown syntax, this will be used in document generation
 	// and the language server.
@@ -66,7 +64,8 @@ func New(version string) func() *schema.Provider {
 }
 
 // configure initializes the global provider with sensible defaults (that mimic what ko does with cli/cobra defaults)
-func configure(version string, p *schema.Provider) func(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {
+// TODO: review input parameters
+func configure(version string, p *schema.Provider) func(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) { //nolint: revive
 	return func(ctx context.Context, s *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		koDockerRepo, ok := s.Get("repo").(string)
 		if !ok {
@@ -93,7 +92,7 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 			}
 		}
 
-		return &providerOpts{
+		return &Opts{
 			bo: &options.BuildOptions{},
 			po: &options.PublishOptions{
 				DockerRepo: koDockerRepo,
@@ -103,14 +102,14 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 	}
 }
 
-type providerOpts struct {
+type Opts struct {
 	bo   *options.BuildOptions
 	po   *options.PublishOptions
 	auth *authn.Basic
 }
 
-func NewProviderOpts(meta interface{}) (*providerOpts, error) {
-	opts, ok := meta.(*providerOpts)
+func NewProviderOpts(meta interface{}) (*Opts, error) {
+	opts, ok := meta.(*Opts)
 	if !ok {
 		return nil, fmt.Errorf("parsing provider args: %v", meta)
 	}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 var providerFactories = map[string]func() (*schema.Provider, error){
-	"ko": func() (*schema.Provider, error) {
+	"ko": func() (*schema.Provider, error) { //nolint: unparam
 		return New("dev")(), nil
 	},
 }

--- a/internal/provider/resource_ko_build.go
+++ b/internal/provider/resource_ko_build.go
@@ -16,7 +16,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/ko/pkg/build"
-	"github.com/google/ko/pkg/commands"
 	"github.com/google/ko/pkg/commands/options"
 	"github.com/google/ko/pkg/publish"
 	"github.com/hashicorp/go-cty/cty"
@@ -107,27 +106,6 @@ func resourceBuild() *schema.Resource {
 			},
 		},
 	}
-}
-
-type buildOpts struct { //nolint: unused
-	*options.BuildOptions
-}
-
-func (o *buildOpts) makeBuilder(ctx context.Context) (*build.Caching, error) { //nolint: unused
-	builder, err := commands.NewBuilder(ctx, o.BuildOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	return build.NewCaching(builder)
-}
-
-type publishOpts struct { //nolint: unused
-	*options.PublishOptions
-}
-
-func (o *publishOpts) makePublisher() (publish.Interface, error) { //nolint: unused
-	return commands.NewPublisher(o.PublishOptions)
 }
 
 type buildOptions struct {

--- a/internal/provider/resource_ko_build_test.go
+++ b/internal/provider/resource_ko_build_test.go
@@ -166,7 +166,7 @@ func TestAccResourceKoBuild_ProviderRepo(t *testing.T) {
 	t.Setenv("KO_DOCKER_REPO", url)
 
 	var providerConfigured = map[string]func() (*schema.Provider, error){
-		"ko": func() (*schema.Provider, error) {
+		"ko": func() (*schema.Provider, error) { //nolint: unparam
 			p := New("dev")()
 			p.Schema["repo"].Default = url + "/configured-in-provider"
 			return p, nil

--- a/internal/provider/resource_ko_image.go
+++ b/internal/provider/resource_ko_image.go
@@ -158,16 +158,16 @@ func resourceImageV0() *schema.Resource {
 	}
 }
 
-func resourceKoImageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	d.Set("image_ref", "")
+func resourceKoImageCreate(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	_ = d.Set("image_ref", "")
 	d.SetId("id")
 	return nil
 }
 
-func resourceKoImageRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceKoImageRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	return nil
 }
 
-func resourceKoImageDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceKoImageDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	return nil
 }

--- a/internal/provider/resource_ko_resolve.go
+++ b/internal/provider/resource_ko_resolve.go
@@ -27,7 +27,7 @@ func resolveConfig() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			FilenamesKey: {
-				Description: "Filenames, directorys, or URLs to files to use to create the resource",
+				Description: "Filenames, directories, or URLs to files to use to create the resource",
 				Required:    true,
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -99,29 +99,29 @@ func resolveConfig() *schema.Resource {
 	}
 }
 
-type Resolver interface {
+type ResolverInt interface {
 	Resolve(ctx context.Context) (*Resolved, error)
 }
 
 type Resolved struct {
-	Id        string
+	ID        string
 	Manifests []string
 }
 
-type resolver struct {
+type Resolver struct {
 	bo *options.BuildOptions
 	po *options.PublishOptions
 	fo *options.FilenameOptions
 	so *options.SelectorOptions
 }
 
-func NewResolver(d *schema.ResourceData, meta interface{}) (*resolver, error) {
+func NewResolver(d *schema.ResourceData, meta interface{}) (*Resolver, error) {
 	opts, err := NewProviderOpts(meta)
 	if err != nil {
 		return nil, err
 	}
 
-	r := &resolver{
+	r := &Resolver{
 		bo: opts.bo,
 		po: opts.po,
 		fo: &options.FilenameOptions{},
@@ -163,7 +163,7 @@ func NewResolver(d *schema.ResourceData, meta interface{}) (*resolver, error) {
 	return r, nil
 }
 
-func (r *resolver) Resolve(ctx context.Context) (*Resolved, error) {
+func (r *Resolver) Resolve(ctx context.Context) (*Resolved, error) {
 	builder, err := commands.NewBuilder(ctx, r.bo)
 	if err != nil {
 		return nil, err
@@ -219,7 +219,7 @@ func (r *resolver) Resolve(ctx context.Context) (*Resolved, error) {
 	sha256hash := sha256.Sum256(resolveBuf.Bytes())
 
 	return &Resolved{
-		Id:        fmt.Sprintf("%x", sha256hash),
+		ID:        fmt.Sprintf("%x", sha256hash),
 		Manifests: manifests,
 	}, nil
 }
@@ -235,8 +235,8 @@ func resourceKoResolveCreate(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.Errorf("resolving: %v", err)
 	}
 
-	d.SetId(resolved.Id)
-	d.Set("manifests", resolved.Manifests)
+	d.SetId(resolved.ID)
+	_ = d.Set("manifests", resolved.Manifests)
 	return nil
 }
 
@@ -254,14 +254,14 @@ func resourceKoResolveRead(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("resolving: %v", err)
 	}
 
-	d.Set("manifests", resolved.Manifests)
-	if resolved.Id != d.Id() {
+	_ = d.Set("manifests", resolved.Manifests)
+	if resolved.ID != d.Id() {
 		d.SetId("")
 	}
 	return nil
 }
 
-func resourceKoResolveDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceKoResolveDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics { //nolint: unused
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 var (
 	// these will be set by the goreleaser configuration
 	// to appropriate values for the compiled binary
-	version string = "dev"
+	version = "dev"
 
 	// goreleaser can also pass the specific commit if you want
 	// commit  string = ""


### PR DESCRIPTION
- update to go 1.20
- add golangci-lint config and job
- use git hashes instead of tags, add build job and format goreleaser