### PR TITLE
use minimal base image for lambda example

### DIFF
--- a/provider-examples/lambda/lambda.tf
+++ b/provider-examples/lambda/lambda.tf
@@ -30,7 +30,6 @@ resource "aws_ecr_repository" "foo" {
 
 resource "ko_build" "image" {
   repo        = aws_ecr_repository.foo.repository_url
-  base_image  = "public.ecr.aws/lambda/provided:al2"
   importpath  = "github.com/ko-build/terraform-provider-ko/cmd/test-lambda"
   working_dir = path.module
   // Disable SBOM generation due to
@@ -42,14 +41,14 @@ resource "aws_iam_role" "lambda_access_role" {
   name = "lambda_access_role"
 
   assume_role_policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
+    "Version" : "2012-10-17",
+    "Statement" : [
       {
-        "Effect": "Allow",
-        "Principal": {
-          "Service": "lambda.amazonaws.com"
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "lambda.amazonaws.com"
         },
-        "Action": "sts:AssumeRole"
+        "Action" : "sts:AssumeRole"
       }
     ]
   })


### PR DESCRIPTION
It turns out the base image doesn't matter, so long as you invoke the handler using the `aws-lambda-go` handler wrapper

https://docs.aws.amazon.com/lambda/latest/dg/go-image.html#go-image-other describes using alpine as a base, but `ko`'s default `cgr.dev/chainguard/static` works just as well.

This brings the image size from 112MB to 6MB 📉 (zero vulns either way)