### PR TITLE
set -trimpath to builds

### DIFF
--- a/internal/provider/resource_ko_build.go
+++ b/internal/provider/resource_ko_build.go
@@ -137,6 +137,7 @@ var (
 
 func (o *buildOptions) makeBuilder(ctx context.Context) (*build.Caching, error) {
 	bo := []build.Option{
+		build.WithTrimpath(true),
 		build.WithPlatforms(o.platforms...),
 		build.WithBaseImages(func(ctx context.Context, s string) (name.Reference, build.Result, error) {
 			ref, err := name.ParseReference(o.baseImage)


### PR DESCRIPTION
This is defaulted to true in `ko` CLI, but only by defaulting the flag, and not the build option: https://github.com/ko-build/ko/blob/4100cbad34f9480cb24d6a03e4fa1be31b6a19d0/pkg/commands/options/build.go#L87

In tf-ko we can be more opinionated about always `trimpath`ing, which produces two different builds if the same importpath is built through two different modules.