### PR TITLE
Add base_image provider setting.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ provider "ko" {
 
 ### Optional
 
+- `base_image` (String) Default base image for builds
 - `basic_auth` (String) Basic auth to use to authorize requests
 - `docker_repo` (String) [DEPRECATED: use `repo`] Container repository to publish images to. Defaults to `KO_DOCKER_REPO` env var
 - `repo` (String) Container repository to publish images to. Defaults to `KO_DOCKER_REPO` env var

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -49,6 +49,12 @@ func New(version string) func() *schema.Provider {
 					Default:     "",
 					Type:        schema.TypeString,
 				},
+				BaseImageKey: {
+					Description: "Default base image for builds",
+					Optional:    true,
+					Default:     "",
+					Type:        schema.TypeString,
+				},
 			},
 			ResourcesMap: map[string]*schema.Resource{
 				"ko_image":   resourceImage(),
@@ -78,6 +84,11 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 			}
 		}
 
+		baseImage, ok := s.Get(BaseImageKey).(string)
+		if !ok {
+			return nil, diag.Errorf("expected base_image to be string")
+		}
+
 		var auth *authn.Basic
 		if a, ok := s.Get("basic_auth").(string); !ok {
 			return nil, diag.Errorf("expected basic_auth to be string")
@@ -93,7 +104,9 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 		}
 
 		return &Opts{
-			bo: &options.BuildOptions{},
+			bo: &options.BuildOptions{
+				BaseImage: baseImage,
+			},
 			po: &options.PublishOptions{
 				DockerRepo: koDockerRepo,
 			},

--- a/internal/provider/resource_ko_build.go
+++ b/internal/provider/resource_ko_build.go
@@ -28,8 +28,7 @@ import (
 )
 
 const (
-	defaultBaseImage = "cgr.dev/chainguard/static"
-	version          = "devel"
+	version = "devel"
 )
 
 var validTypes = map[string]struct{}{
@@ -77,7 +76,7 @@ func resourceBuild() *schema.Resource {
 			},
 			BaseImageKey: {
 				Description: "base image to use",
-				Default:     defaultBaseImage,
+				Default:     "",
 				Optional:    true,
 				Type:        schema.TypeString,
 				ForceNew:    true, // Any time this changes, don't try to update in-place, just create it.
@@ -255,11 +254,18 @@ func fromData(d *schema.ResourceData, po *Opts) buildOptions {
 		workingDir: d.Get("working_dir").(string),
 		imageRepo:  repo,
 		platforms:  toStringSlice(d.Get("platforms").([]interface{})),
-		baseImage:  d.Get("base_image").(string),
+		baseImage:  getString(d, BaseImageKey, po.bo.BaseImage),
 		sbom:       d.Get("sbom").(string),
 		auth:       po.auth,
 		bare:       bare,
 	}
+}
+
+func getString(d *schema.ResourceData, key string, defaultVal string) string {
+	if v, ok := d.Get(key).(string); ok && v != "" {
+		return v
+	}
+	return defaultVal
 }
 
 func toStringSlice(in []interface{}) []string {

--- a/internal/provider/resource_ko_image.go
+++ b/internal/provider/resource_ko_image.go
@@ -73,7 +73,7 @@ func resourceImage() *schema.Resource {
 			},
 			BaseImageKey: {
 				Description: "base image to use",
-				Default:     defaultBaseImage,
+				Default:     "",
 				Optional:    true,
 				Type:        schema.TypeString,
 				ForceNew:    true, // Any time this changes, don't try to update in-place, just create it.
@@ -137,7 +137,7 @@ func resourceImageV0() *schema.Resource {
 			},
 			BaseImageKey: {
 				Description: "base image to use",
-				Default:     defaultBaseImage,
+				Default:     "",
 				Optional:    true,
 				Type:        schema.TypeString,
 				ForceNew:    true, // Any time this changes, don't try to update in-place, just create it.

--- a/internal/provider/resource_ko_resolve.go
+++ b/internal/provider/resource_ko_resolve.go
@@ -68,7 +68,7 @@ func resolveConfig() *schema.Resource {
 			},
 			BaseImageKey: {
 				Description: "",
-				Default:     defaultBaseImage,
+				Default:     "",
 				Optional:    true,
 				Type:        schema.TypeString,
 				ForceNew:    true,


### PR DESCRIPTION
Adds a base_image provider setting in order to allow setting a global base image default for ko.

This unfortunately requires unsetting the default base image as the default in the resource args, since this is indistinguishable from whether the user set the field or not. :( (if there's a better way to do this lmk!)