### PR TITLE
remove provider `docker_repo`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 page_title: "ko Provider"
 subcategory: ""
 description: |-
-
+  
 ---
 
 # ko Provider

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 page_title: "ko Provider"
 subcategory: ""
 description: |-
-  
+
 ---
 
 # ko Provider
@@ -14,7 +14,7 @@ description: |-
 
 ```terraform
 provider "ko" {
-  docker_repo = "ttl.sh/foo"
+  repo = "ttl.sh/foo"
 }
 ```
 
@@ -25,5 +25,4 @@ provider "ko" {
 
 - `base_image` (String) Default base image for builds
 - `basic_auth` (String) Basic auth to use to authorize requests
-- `docker_repo` (String) [DEPRECATED: use `repo`] Container repository to publish images to. Defaults to `KO_DOCKER_REPO` env var
 - `repo` (String) Container repository to publish images to. Defaults to `KO_DOCKER_REPO` env var

--- a/docs/resources/build.md
+++ b/docs/resources/build.md
@@ -25,7 +25,7 @@ Sample resource in the Terraform provider scaffolding.
 - `env` (List of String) Extra environment variables to pass to the go build
 - `ldflags` (List of String) Extra ldflags to pass to the go build
 - `platforms` (List of String) Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-- `repo` (String) Container repository to publish images to. If set, this overrides the provider's docker_repo, and the image name will be exactly the specified `repo`, without the importpath appended.
+- `repo` (String) Container repository to publish images to. If set, this overrides the provider's `repo`, and the image name will be exactly the specified `repo`, without the importpath appended.
 - `sbom` (String) The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m).
 - `working_dir` (String) working directory for the build
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,3 +1,3 @@
 provider "ko" {
-  docker_repo = "ttl.sh/foo"
+  repo = "ttl.sh/foo"
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -31,12 +31,6 @@ func New(version string) func() *schema.Provider {
 	return func() *schema.Provider {
 		p := &schema.Provider{
 			Schema: map[string]*schema.Schema{
-				"docker_repo": {
-					Description: "[DEPRECATED: use `repo`] Container repository to publish images to. Defaults to `KO_DOCKER_REPO` env var",
-					Optional:    true,
-					DefaultFunc: schema.EnvDefaultFunc("KO_DOCKER_REPO", ""),
-					Type:        schema.TypeString,
-				},
 				"repo": {
 					Description: "Container repository to publish images to. Defaults to `KO_DOCKER_REPO` env var",
 					Optional:    true,
@@ -75,12 +69,6 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 		koDockerRepo, ok := s.Get("repo").(string)
 		if !ok {
 			return nil, diag.Errorf("expected repo to be string")
-		}
-		if koDockerRepo == "" {
-			koDockerRepo, ok = s.Get("docker_repo").(string)
-			if !ok {
-				return nil, diag.Errorf("expected docker_repo to be string")
-			}
 		}
 
 		baseImage, ok := s.Get(BaseImageKey).(string)

--- a/internal/provider/resource_ko_build.go
+++ b/internal/provider/resource_ko_build.go
@@ -96,7 +96,7 @@ func resourceBuild() *schema.Resource {
 				},
 			},
 			RepoKey: {
-				Description: "Container repository to publish images to. If set, this overrides the provider's docker_repo, and the image name will be exactly the specified `repo`, without the importpath appended.",
+				Description: "Container repository to publish images to. If set, this overrides the provider's `repo`, and the image name will be exactly the specified `repo`, without the importpath appended.",
 				Default:     "",
 				Optional:    true,
 				Type:        schema.TypeString,
@@ -231,7 +231,7 @@ var baseImages sync.Map // Cache of base image lookups.
 // doBuild doesn't publish images, use doPublish to publish the build.Result that doBuild returns.
 func doBuild(ctx context.Context, opts buildOptions) (build.Result, string, error) {
 	if opts.imageRepo == "" {
-		return nil, "", errors.New("one of KO_DOCKER_REPO env var, or provider `docker_repo` or `repo`, or image resource `repo` must be set")
+		return nil, "", errors.New("one of KO_DOCKER_REPO env var, or provider `repo`, or image resource `repo` must be set")
 	}
 
 	b, err := opts.makeBuilder(ctx)

--- a/provider-examples/apprunner/apprunner.tf
+++ b/provider-examples/apprunner/apprunner.tf
@@ -16,7 +16,7 @@ provider "aws" {
 
 provider "ko" {
   // This is added as a check that `repo` works below, it should never be used.
-  docker_repo = "example.com"
+  repo = "example.com"
 }
 
 resource "aws_ecr_repository" "foo" {
@@ -42,33 +42,33 @@ resource "aws_iam_role" "apprunner_access_role" {
   name = "apprunner_access_role"
 
   assume_role_policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
+    "Version" : "2012-10-17",
+    "Statement" : [
       {
-        "Effect": "Allow",
-        "Principal": {
-          "Service": "build.apprunner.amazonaws.com"
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "build.apprunner.amazonaws.com"
         },
-        "Action": "sts:AssumeRole"
+        "Action" : "sts:AssumeRole"
       }
     ]
   })
 
   inline_policy {
-    name   = "can-pull-ecr"
+    name = "can-pull-ecr"
     policy = jsonencode({
-      "Version": "2012-10-17",
-      "Statement": [
+      "Version" : "2012-10-17",
+      "Statement" : [
         {
-          "Action": [
+          "Action" : [
             "ecr:GetDownloadUrlForLayer",
             "ecr:BatchGetImage",
             "ecr:DescribeImages",
             "ecr:GetAuthorizationToken",
             "ecr:BatchCheckLayerAvailability",
           ],
-          "Resource": "*",
-          "Effect": "Allow"
+          "Resource" : "*",
+          "Effect" : "Allow"
         }
       ]
     })

--- a/provider-examples/ecs/ecs.tf
+++ b/provider-examples/ecs/ecs.tf
@@ -20,7 +20,7 @@ provider "aws" {
 
 provider "ko" {
   // This is added as a check that `repo` works below, it should never be used.
-  docker_repo = "example.com"
+  repo = "example.com"
 }
 
 resource "aws_ecr_repository" "foo" {
@@ -46,20 +46,20 @@ resource "aws_iam_role" "example" {
   name = "terraform-ecs-ko"
 
   assume_role_policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
+    "Version" : "2012-10-17",
+    "Statement" : [
       {
-        "Effect": "Allow",
-        "Principal": {
-          "Service": "ecs.amazonaws.com"
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "ecs.amazonaws.com"
         },
-        "Action": "sts:AssumeRole"
-      },{
-        "Effect": "Allow",
-        "Principal": {
-          "Service": "ecs-tasks.amazonaws.com"
+        "Action" : "sts:AssumeRole"
+        }, {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "ecs-tasks.amazonaws.com"
         },
-        "Action": "sts:AssumeRole"
+        "Action" : "sts:AssumeRole"
       }
     ]
   })
@@ -87,7 +87,7 @@ resource "aws_ecs_service" "foo" {
   }
   network_configuration {
     assign_public_ip = true
-    subnets = [var.subnet]
+    subnets          = [var.subnet]
   }
 }
 
@@ -98,19 +98,19 @@ resource "aws_ecs_task_definition" "foo" {
   execution_role_arn       = aws_iam_role.example.arn
   cpu                      = 1024
   memory                   = 2048
-  container_definitions    = jsonencode([
+  container_definitions = jsonencode([
     {
-      "name": "foo",
-      "image": ko_build.image.image_ref,
-      "cpu": 1024,
-      "memory": 2048,
-      "essential": true
+      "name" : "foo",
+      "image" : ko_build.image.image_ref,
+      "cpu" : 1024,
+      "memory" : 2048,
+      "essential" : true
     }
   ])
 }
 
 resource "aws_ecs_cluster_capacity_providers" "cluster" {
-  cluster_name = aws_ecs_cluster.cluster.name
+  cluster_name       = aws_ecs_cluster.cluster.name
   capacity_providers = ["FARGATE"]
   default_capacity_provider_strategy {
     base              = 1

--- a/provider-examples/lambda/lambda.tf
+++ b/provider-examples/lambda/lambda.tf
@@ -16,7 +16,7 @@ provider "aws" {
 
 provider "ko" {
   // This is added as a check that `repo` works below, it should never be used.
-  docker_repo = "example.com"
+  repo = "example.com"
 }
 
 resource "aws_ecr_repository" "foo" {

--- a/provider-examples/lightsail/lightsail.tf
+++ b/provider-examples/lightsail/lightsail.tf
@@ -16,7 +16,7 @@ provider "aws" {
 
 provider "ko" {
   // This is added as a check that `repo` works below, it should never be used.
-  docker_repo = "example.com"
+  repo = "example.com"
 }
 
 resource "aws_ecr_repository" "foo" {
@@ -58,15 +58,15 @@ resource "aws_ecr_repository_policy" "lightsail_ecr_download" {
   repository = aws_ecr_repository.foo.name
 
   policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
+    "Version" : "2012-10-17",
+    "Statement" : [
       {
-        "Sid": "AllowLightsailPull",
-        "Effect": "Allow",
-        "Principal": {
-          "AWS": "${aws_lightsail_container_service.example.private_registry_access[0].ecr_image_puller_role[0].principal_arn}"
+        "Sid" : "AllowLightsailPull",
+        "Effect" : "Allow",
+        "Principal" : {
+          "AWS" : "${aws_lightsail_container_service.example.private_registry_access[0].ecr_image_puller_role[0].principal_arn}"
         },
-        "Action": [
+        "Action" : [
           "ecr:BatchGetImage",
           "ecr:GetDownloadUrlForLayer"
         ]


### PR DESCRIPTION
It's been deprecated for a while, `repo` is the preferred replacement.