### PR TITLE
don't fail plan when ko build fails

### DIFF
--- a/internal/provider/resource_ko_build_test.go
+++ b/internal/provider/resource_ko_build_test.go
@@ -113,23 +113,21 @@ func TestAccResourceKoBuild(t *testing.T) {
 		}},
 	})
 
-	/*
-		resource.Test(t, resource.TestCase{
-			ProviderFactories: providerFactories,
-			Steps: []resource.TestStep{{
-				Config: `
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{{
+			Config: `
 				resource "ko_build" "foo" {
 				  importpath = "github.com/ko-build/terraform-provider-ko/cmd/test-cgo"
 				  env     = ["CGO_ENABLED=1"]
 				}
 				`,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("ko_build.foo", "image_ref",
-						regexp.MustCompile("^"+url+"/github.com/ko-build/terraform-provider-ko/cmd/test-cgo@sha256:")),
-				),
-			}},
-		})
-	*/
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestMatchResourceAttr("ko_build.foo", "image_ref",
+					regexp.MustCompile("^"+url+"/github.com/ko-build/terraform-provider-ko/cmd/test-cgo@sha256:")),
+			),
+		}},
+	})
 
 	for _, sbom := range []string{"spdx", "cyclonedx", "go.version-m", "none"} {
 		resource.Test(t, resource.TestCase{


### PR DESCRIPTION
Expanding on https://github.com/ko-build/terraform-provider-ko/pull/108

This prevents ko build failures of all kinds from blocking planning. It seems there may be cases where the `ko_build` in TF state is now invalid, and can't be updated because we never get to a successful create phase. Previously the most common example of this was that the importpath changed and the underlying directory was renamed -- this generalizes to handle all cases where the TF state's build is no longer valid but needs to get updated if we can build the new state.

