### PR TITLE
feat: added support for custom tags

### DIFF
--- a/docs/resources/build.md
+++ b/docs/resources/build.md
@@ -27,6 +27,7 @@ Sample resource in the Terraform provider scaffolding.
 - `platforms` (List of String) Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
 - `repo` (String) Container repository to publish images to. If set, this overrides the provider's `repo`, and the image name will be exactly the specified `repo`, without the importpath appended.
 - `sbom` (String) The SBOM media type to use (none will disable SBOM synthesis and upload).
+- `tags` (List of String) Which tags to use for the produced image instead of the default 'latest' tag
 - `working_dir` (String) working directory for the build
 
 ### Read-Only


### PR DESCRIPTION
## Goal
This PR is aimed at adding support for publishing multiple image tags. This makes use of the existing feature-set provided by upstream `ko-build/ko` through the usage of the `--tags` flag.
cf. https://github.com/ko-build/ko/blob/0dcace336cc5f723150d77487dbaf56f849cc361/docs/reference/ko_build.md?plain=1#L62

By adding this functionality one is then able to avoid having to collide with an existing `stable` tag which is always named `latest`. This also opens the door for the usage of `semver`. 

## What changed?
+ Added an optional `tags` schema field that takes a list of strings. If not provided, backwards compatibility is maintained by defaulting to the usage of the `latest` tag.
+ Added new test suite `TestAccResourceKoBuild_Tags` to assert that new functionality works as expected and backwards compatibility is maintained.

## Tests
<img width="354" alt="image" src="https://github.com/ko-build/terraform-provider-ko/assets/16003878/4a479749-2b17-4b41-883e-60c9e042cf98">


## Example usage
```hcl
resource "ko_build" "this" {
  sbom        = "<your_sbom>"
  tags        = ["develop"]
  importpath  = "<your_importpath>"
  repo        = "<your_repo>"
  working_dir = "<your_work_dir>"
}
```