### PR TITLE
Updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,12 @@ jobs:
         with:
           go-version-file: './go.mod'
           check-latest: true
+
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: '1.10.*'
+          terraform_wrapper: false
+
       - run: go generate ./...
       - name: git diff
         run: |
@@ -27,9 +33,9 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - '1.7.*'
           - '1.8.*'
           - '1.9.*'
+          - '1.10.*'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,4 +22,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
-          version: v1.61
+          version: v1.62

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ko-build/terraform-provider-ko
 
-go 1.23.2
+go 1.23.4
 
 require (
 	github.com/aws/aws-lambda-go v1.47.0


### PR DESCRIPTION
- update golangci-lint
- add terraform 1.10.x and drop 1.7.x