### PR TITLE
Updates ci/go.mo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
-          terraform_version: '1.10.*'
+          terraform_version: '1.11.*'
           terraform_wrapper: false
 
       - run: go generate ./...
@@ -33,9 +33,9 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - '1.8.*'
           - '1.9.*'
           - '1.10.*'
+          - '1.11.*'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,6 +20,6 @@ jobs:
           check-latest: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: v1.62
+          version: v2.1

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,25 +1,40 @@
-run:
-  timeout: 10m
-
-issues:
-  exclude-rules:
-    - path: test # Excludes /test, *_test.go etc.
-      linters:
-        - gosec
-
+version: "2"
 linters:
   enable:
     - asciicheck
     - errorlint
-    - gofmt
     - gosec
-    - goimports
     - importas
+    - misspell
     - prealloc
     - revive
-    - misspell
-    - stylecheck
+    - staticcheck
     - tparallel
     - unconvert
     - unparam
     - whitespace
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gosec
+        path: test
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ko-build/terraform-provider-ko
 
-go 1.23.4
+go 1.24
 
 require (
 	github.com/aws/aws-lambda-go v1.48.0


### PR DESCRIPTION
- test with terraform 1.11 and drop 1.8
- upgrade golangci-lint to v2
- update go.mod to go1.24